### PR TITLE
fixed long description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pep8.txt
 /dist/
 /.tox/
 /.vagrant/
+venv/

--- a/setup.py
+++ b/setup.py
@@ -55,10 +55,10 @@ class UltraMagicString(object):
         return str(self).split(*args, **kw)
 
 
-long_description = UltraMagicString('\n\n'.join((
+long_description = '\n\n'.join((
     read('README.rst'),
     read('CHANGES.rst'),
-)))
+))
 
 version = find_version('sortedm2m_filter_horizontal_widget', '__init__.py')
 


### PR DESCRIPTION
long description was using non ASCII characters. 
UltraMagicString class was created as a workaround.
When installing this package with setuptools.py installed, egg-info threw an error where UltraMagicString was the issue.
Have removed UltraMagicString - doesn't seem to be an issue previewing the long-description html with rst2html.
Have tested on a Docker container to ensure this installs successfully with setuptools.